### PR TITLE
Add version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 obj
 bin
 __pycache__
+src/version.ads

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libkeccak"]
 	path = libkeccak
-	url = https://@github.com:damaki/libkeccak.git
+	url = https://github.com/damaki/libkeccak.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libkeccak"]
+	path = libkeccak
+	url = git@github.com:damaki/libkeccak.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libkeccak"]
 	path = libkeccak
-	url = git@github.com:damaki/libkeccak.git
+	url = https://@github.com:damaki/libkeccak.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
     master
 
 git:
-  submodules: false
+  submodules: true
 
 script:
   - ./travis_build.sh

--- a/README.md
+++ b/README.md
@@ -174,12 +174,12 @@ downloaded separately at the above AdaCore link.
 implement the various algorithms that `ksum` supports (e.g. SHA-3).
 
 To build `libkeccak` and `ksum`:
-  1. `git clone --recursive git@github.com:damaki/ksum.git`
+  1. `git clone --recursive https://github.com/damaki/ksum.git`
   2. `cd ksum`
   3. `cd libkeccak`
   4. `make install`
   5. `cd ..`
-  6. `gprbuild -p -P ksum.gpr -j0 -XLIBKECCAK_BUILD=default`
+  6. `./build.sh`
 
 If you have already built & installed `libkeccak` then you can skip steps 3, 4, and 5.
 
@@ -216,12 +216,6 @@ The table also includes the output of other checksum programs for reference
 | **sha256sum bigfile**          | 0m8.276s  | 0m8.124s  | 0m0.148s |
 | **sha224sum bigfile**          | 0m8.296s  | 0m8.124s  | 0m0.168s |
 | ksum --sha3-512 bigfile        | 0m11.437s | 0m11.260s | 0m0.172s |
-
-## TODO
-
-Things not yet implemented:
-  * Testing against test vectors.
-    (although `libkeccak` itself is tested against test vectors)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -167,19 +167,21 @@ Building `ksum` requires an Ada 2012 compatible compiler which also understands
 SPARK 2014. One such compiler is
 [GNAT GPL 2017 from AdaCore](https://libre.adacore.com/download).
 
-`ksum` is built using `gprbuild`, which is included in GNAT GPL 2017 or can be
+`ksum` is built using `gprbuild`, which is included in GNAT GPL 2019 or can be
 downloaded separately at the above AdaCore link.
 
-You will also need to build and install [`libkeccak`](https://github.com/damaki/libkeccak):
-  1. `git clone git@github.com:damaki/libkeccak.git`
-  2. `cd libkeccak`
-  3. `make build`
-  4. `make install`
+`ksum` is depends on [`libkeccak`](https://github.com/damaki/libkeccak) to
+implement the various algorithms that `ksum` supports (e.g. SHA-3).
 
-To build `ksum`:
-  1. `git clone git@github.com:damaki/ksum.git`
+To build `libkeccak` and `ksum`:
+  1. `git clone --recursive git@github.com:damaki/ksum.git`
   2. `cd ksum`
-  3. `gprbuild -p -P ksum.gpr -XLIBKECCAK_BUILD=default`
+  3. `cd libkeccak`
+  4. `make install`
+  5. `cd ..`
+  6. `gprbuild -p -P ksum.gpr -j0 -XLIBKECCAK_BUILD=default`
+
+If you have already built & installed `libkeccak` then you can skip steps 3, 4, and 5.
 
 The `ksum` executable will be placed in the `bin` directory.
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ The default block size for ParallelHash is 8192 bytes (8 kiB).
 
 Building `ksum` requires an Ada 2012 compatible compiler which also understands
 SPARK 2014. One such compiler is
-[GNAT GPL 2017 from AdaCore](https://libre.adacore.com/download).
+[GNAT Community 2019 from AdaCore](https://libre.adacore.com/download).
 
-`ksum` is built using `gprbuild`, which is included in GNAT GPL 2019 or can be
+`ksum` is built using `gprbuild`, which is included in GNAT Community 2019 or can be
 downloaded separately at the above AdaCore link.
 
 `ksum` is depends on [`libkeccak`](https://github.com/damaki/libkeccak) to

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo Generating src/version.ads ...
+./gen-version-ads.sh
+
+echo Building ksum ...
+gprbuild -p -P ksum.gpr -j0 -XLIBKECCAK_BUILD=default
+echo Done

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,12 @@
 echo Generating src/version.ads ...
 ./gen-version-ads.sh
 
+if [ $? != 0 ]
+then
+  echo Failed to generate version. Exiting.
+  exit $?
+fi
+
 echo Building ksum ...
 gprbuild -p -P ksum.gpr -j0 -XLIBKECCAK_BUILD=default
 echo Done

--- a/gen-version-ads.sh
+++ b/gen-version-ads.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This script generates a file src/version.ads which contains a
+# version string based on the output of git describe.
+
+VERSION=`git describe --tags`
+
+# Check if git describe was successful
+if [ $? = 0 ]
+then
+  echo "package Version is" > src/version.ads
+  echo "   Version_String : constant String := \"$VERSION\";" >> src/version.ads
+  echo "end Version;" >> src/version.ads
+
+  echo Done
+else
+  exit $?
+fi

--- a/src/configurations.adb
+++ b/src/configurations.adb
@@ -21,6 +21,8 @@ with Ada.Text_IO;       use Ada.Text_IO;
 with Argument_Parser;   use Argument_Parser;
 with Hex_Strings;       use Hex_Strings;
 
+with Version; --  Generated spec
+
 package body Configurations
 is
 
@@ -39,6 +41,7 @@ is
    procedure Set_Algorithm     (Short_Name, Long_Name, Arg : in String);
    procedure Add_Stdin         (Short_Name, Long_Name, Arg : in String);
    procedure Print_Help        (Short_Name, Long_Name, Arg : in String);
+   procedure Print_Version     (Short_Name, Long_Name, Arg : in String);
 
    procedure Print_Switches (Group : in Argument_Parser.Group_Type);
 
@@ -310,6 +313,23 @@ is
 
    end Print_Help;
 
+   procedure Print_Version (Short_Name, Long_Name, Arg : in String)
+   is
+      pragma Unreferenced (Short_Name);
+      pragma Unreferenced (Long_Name);
+      pragma Unreferenced (Arg);
+   begin
+      Help_Displayed := True;
+
+      Put ("ksum ");
+      Put_Line (Version.Version_String);
+      Put_Line ("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>");
+      Put_Line ("This is free software: you are free to change and redistribute it.");
+      Put_Line ("There is NO WARRANTY, to the extent permitted by law.");
+      New_Line;
+      Put_Line ("Written by Daniel King.");
+   end Print_Version;
+
    --------------------
    --  Switch Table  --
    --------------------
@@ -324,10 +344,17 @@ is
 
       (Short_Name   => To_Unbounded_String ("-h"),
        Long_Name    => To_Unbounded_String ("--help"),
-       Description  => To_Unbounded_String ("Print this message"),
+       Description  => To_Unbounded_String ("Print this message and exit"),
        Group        => Argument_Parser.Main_Switches,
        Has_Argument => False,
        Handler      => Print_Help'Access),
+
+      (Short_Name   => To_Unbounded_String ("-v"),
+       Long_Name    => To_Unbounded_String ("--version"),
+       Description  => To_Unbounded_String ("Print version information and exit"),
+       Group        => Argument_Parser.Main_Switches,
+       Has_Argument => False,
+       Handler      => Print_Version'Access),
 
       (Short_Name   => To_Unbounded_String ("-c"),
        Long_Name    => To_Unbounded_String ("--check"),

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && ./build.sh"
+docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && ls && ./build.sh"
 cd tests
 python3 run_tests.py --verbose

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-git clone https://github.com/damaki/libkeccak.git
-docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && gprbuild -p -P ksum.gpr -f -j0 -XLIBKECCAK_BUILD=default"
+docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && ./build.sh"
 cd tests
 python3 run_tests.py --verbose

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && ls && ./build.sh"
+docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && sh build.sh"
 cd tests
 python3 run_tests.py --verbose

--- a/travis_build.sh
+++ b/travis_build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && sh build.sh"
+sh gen-version-ads.sh
+docker run -v $PWD:/app -w /app jklmnn/gnat:gpl.2019.spark /bin/sh -c "cd libkeccak && make install && cd .. && gprbuild -p -P ksum.gpr -j0 -XLIBKECCAK_BUILD=default"
 cd tests
 python3 run_tests.py --verbose


### PR DESCRIPTION
This implements the `--version` switch to display version information.

The version string is generated at build time by `gen-version-ads.sh` which generates the file `src/version.ads` containing the string. The version string is simply the output of `git describe --tags`.

`libkeccak` is also linked as a Git submodule to simplify reproducibility of release builds.