### PR TITLE
Fix failure to read past SUB characters in Windows

### DIFF
--- a/src/checksums.adb
+++ b/src/checksums.adb
@@ -17,12 +17,14 @@
 --  You should have received a copy of the GNU General Public License
 --  along with ksum.  If not, see <http://www.gnu.org/licenses/>.
 -------------------------------------------------------------------------------
+with Ada.Characters.Latin_1;
 with Ada.Text_IO;
 with Ada.Text_IO.Unbounded_IO;
 with Ada.Command_Line;
 with Ada.Directories;       use Ada.Directories;
 with Ada.Exceptions;        use Ada.Exceptions;
 with Ada.IO_Exceptions;
+with Ada.Strings.Maps;
 
 with Configurations;        use Configurations;
 with Diagnostics;           use Diagnostics;
@@ -404,7 +406,16 @@ is
       File_Loop :
       while not Ada.Text_IO.End_Of_File (File) loop
          declare
-            Line : constant Unbounded_String := Ada.Text_IO.Unbounded_IO.Get_Line (File);
+            --  Trim carriage return characters from the end of the line.
+            --  On Windows this is done automatically by Get_Line, but on Unix
+            --  Get_Line does not consume the CR. Therefore, we trim it manually
+            --  to ensure that ksum on Unix can parse checksum files generated
+            --  on Windows.
+            Line : constant Unbounded_String :=
+              Trim (Source => Ada.Text_IO.Unbounded_IO.Get_Line (File),
+                    Left   => Ada.Strings.Maps.Null_Set,
+                    Right  => Ada.Strings.Maps.To_Set (Ada.Characters.Latin_1.CR));
+
             File_Name     : Unbounded_String;
             Expected_Hash : Unbounded_String;
 

--- a/src/file_cshake.adb
+++ b/src/file_cshake.adb
@@ -67,12 +67,10 @@ is
                    Function_Name => To_String (Configurations.Function_Name),
                    Customization => To_String (Configurations.Customization));
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          CSHAKE.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;
@@ -105,12 +103,10 @@ is
                    Function_Name => To_String (Configurations.Function_Name),
                    Customization => To_String (Configurations.Customization));
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          CSHAKE.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;

--- a/src/file_hashing.adb
+++ b/src/file_hashing.adb
@@ -40,12 +40,10 @@ is
    begin
       Hash. Init (Ctx);
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          Hash.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;
@@ -78,12 +76,10 @@ is
       else
          Hash. Init (Ctx);
 
-         while not End_Of_File (File) loop
+         loop
             Read_Byte_Array (Stream (File), Buffer, Length);
 
-            if Length = 0 then
-               raise Program_Error with "Could not read from stream";
-            end if;
+            exit when Length = 0;
 
             Hash.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
          end loop;

--- a/src/file_k12.adb
+++ b/src/file_k12.adb
@@ -68,12 +68,10 @@ is
    begin
       K12.Init (Ctx);
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          K12.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;
@@ -106,12 +104,10 @@ is
    begin
       K12.Init (Ctx);
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          K12.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;

--- a/src/file_kmac.adb
+++ b/src/file_kmac.adb
@@ -97,12 +97,10 @@ is
             Customization => To_String (Configurations.Customization));
       end if;
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          KMAC.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;
@@ -138,12 +136,10 @@ is
             Customization => To_String (Configurations.Customization));
       end if;
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          KMAC.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;

--- a/src/file_parallelhash.adb
+++ b/src/file_parallelhash.adb
@@ -91,12 +91,10 @@ is
          Block_Size    => Configurations.Block_Size,
          Customization => To_String (Configurations.Customization));
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          ParallelHash.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;
@@ -124,12 +122,10 @@ is
          Block_Size    => Configurations.Block_Size,
          Customization => To_String (Configurations.Customization));
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          ParallelHash.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;

--- a/src/file_xof.adb
+++ b/src/file_xof.adb
@@ -64,12 +64,10 @@ is
    begin
       XOF.Init (Ctx);
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          XOF.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;
@@ -100,12 +98,10 @@ is
    begin
       XOF.Init (Ctx);
 
-      while not End_Of_File (File) loop
+      loop
          Read_Byte_Array (Stream (File), Buffer, Length);
 
-         if Length = 0 then
-            raise Program_Error with "Could not read from stream";
-         end if;
+         exit when Length = 0;
 
          XOF.Update (Ctx, Buffer (Buffer'First .. Buffer'First + (Length - 1)));
       end loop;


### PR DESCRIPTION
This changes the way that files are read by avoiding use of the `End_Of_File` function to detect when the end of file is reached. This has problems on Windows systems when a SUB byte `16#1A#` is reached in the input, which the `End_Of_File` functiontreats as an EOF. Instead, we stop reading from the file when no more bytes can be read from it. I.e. when the `Length` returned is 0. This fixes #7.

When reading lines from checksum files, ksum will now strip carriage returns from the end of lines. This allows ksum on Unix to check checksum files generated on Windows, which may contain carriage returns.

The test suite has also been modified to handle carriage return characters in the output from ksum. This allows the test suite to run successfully on Windows.