### PR TITLE
Change default mode from `--text` to `--binary`.

### DIFF
--- a/src/configurations.adb
+++ b/src/configurations.adb
@@ -387,14 +387,14 @@ is
 
       (Short_Name   => To_Unbounded_String ("-t"),
        Long_Name    => To_Unbounded_String ("--text"),
-       Description  => To_Unbounded_String ("read in text mode (default)"),
+       Description  => To_Unbounded_String ("read in text mode"),
        Group        => Argument_Parser.Main_Switches,
        Has_Argument => False,
        Handler      => Set_Read_Mode'Access),
 
       (Short_Name   => To_Unbounded_String ("-b"),
        Long_Name    => To_Unbounded_String ("--binary"),
-       Description  => To_Unbounded_String ("read in binary mode"),
+       Description  => To_Unbounded_String ("read in binary mode (default)"),
        Group        => Argument_Parser.Main_Switches,
        Has_Argument => False,
        Handler      => Set_Read_Mode'Access),

--- a/src/configurations.ads
+++ b/src/configurations.ads
@@ -102,7 +102,7 @@ is
       SHAKE256            => 256 / 8);
    --  Default output length for each algorith, in bytes.
 
-   Read_Mode      : Read_Modes := Text;
+   Read_Mode      : Read_Modes := Binary;
    --  Sets the read mode for reading files (text or binary mode).
    --  Set using -t or -b
 


### PR DESCRIPTION
This is more consistent with other hash programs (e.g. sha256sum) which default to binary mode.